### PR TITLE
Introduce veth(4) pairs for networking access

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
           path: target/release/linux-apex-hypervisor
       - name: Run example
         run: |
-          nix develop -c systemd-run --user --scope -- \
+          nix develop -c unshare -rn systemd-run --user --scope -- \
             target/release/linux-apex-hypervisor --duration $DURATION \
             examples/hello_part/hypervisor_config.yaml
       - name: Export Nix store cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,7 @@ dependencies = [
  "polling",
  "procfs",
  "rand",
+ "regex",
  "serde",
  "thiserror",
  "walkdir",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,6 +22,7 @@ memfd = "0.6"
 bincode = "1.3"
 thiserror = "1.0"
 bytesize = {version = "1.1.0", features = ["serde"]}
+regex = "1.7.0"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod file;
 pub mod health;
 pub mod health_event;
 pub mod ipc;
+pub mod net;
 pub mod partition;
 pub mod queuing;
 pub mod sampling;

--- a/core/src/net.rs
+++ b/core/src/net.rs
@@ -1,0 +1,64 @@
+//! Module for netlink operations
+
+use std::process::Command;
+
+use anyhow::bail;
+use nix::unistd::Pid;
+use regex::Regex;
+
+pub struct VethPair {}
+
+impl VethPair {
+    pub fn new(p1: &str, p2: &str, pid: Pid) -> anyhow::Result<Self> {
+        // Prevent CMD injections by only allowing [A-Za-z0-9_]
+        if !p1.chars().all(|c| char::is_ascii_alphanumeric(&c))
+            || !p2.chars().all(|c| char::is_ascii_alphanumeric(&c))
+        {
+            bail!("interface name is not well-formatted")
+        }
+
+        let cmd = Command::new("ip")
+            .arg("link")
+            .arg("add")
+            .arg(p1)
+            .arg("type")
+            .arg("veth")
+            .arg("peer")
+            .arg(p2)
+            .arg("netns")
+            .arg(pid.to_string())
+            .output()?;
+
+        if !cmd.status.success() {
+            bail!("{}", String::from_utf8(cmd.stderr)?)
+        }
+
+        anyhow::Ok(Self {})
+    }
+
+    // A Drop trait is not necessary, because the veth interface pair will
+    // automatically be deleted, if one side of the pair gets deleted, which
+    // is the case when the child net namespace goes out of scope.
+}
+
+/// Returns all interfaces available in the current namespace
+///
+/// The '@' part of an interface will not be included.
+pub fn get_interfaces() -> anyhow::Result<Vec<String>> {
+    let cmd = Command::new("sh").arg("-c").arg("ip address").output()?;
+    if !cmd.status.success() {
+        bail!("ip-address(8) failed")
+    }
+
+    let str = String::from_utf8(cmd.stdout)?;
+    let re = Regex::new(r"^\d+: ([\w\d]+)")?;
+    let mut result: Vec<String> = Vec::new();
+
+    for line in str.lines() {
+        for cap in re.captures_iter(line) {
+            result.push(cap[1].to_string());
+        }
+    }
+
+    anyhow::Ok(result)
+}

--- a/examples/hello_part/hypervisor_config.yaml
+++ b/examples/hello_part/hypervisor_config.yaml
@@ -6,12 +6,18 @@ partitions:
     offset: 0ms
     period: 500ms
     image: target/x86_64-unknown-linux-musl/release/hello_part
+    veth:
+      - p5:p6
+      - p7:p8
   - id: 1
     name: Bar
     offset: 100ms
     duration: 10ms
     image: target/x86_64-unknown-linux-musl/release/hello_part
     period: 1s
+    veth:
+      - p1:p2
+      - p3:p4
 channel:
   - !Sampling
     name: Hello

--- a/flake.nix
+++ b/flake.nix
@@ -105,7 +105,7 @@
             {
               name = "run-hypervisor-hello-example-scoped";
               command =
-                "systemd-run --user --scope run-hypervisor-hello-example";
+                "unshare -rn systemd-run --user --scope run-hypervisor-hello-example";
               help =
                 ''Run Hypervisor with the "hello" example with systemd-run'';
               category = "dev";

--- a/hypervisor/src/hypervisor/config.rs
+++ b/hypervisor/src/hypervisor/config.rs
@@ -38,6 +38,8 @@ pub struct Partition {
     pub devices: Vec<Device>,
     #[serde(default)]
     pub hm_table: PartitionHMTable,
+    #[serde(default)]
+    pub veth: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/hypervisor/src/hypervisor/linux.rs
+++ b/hypervisor/src/hypervisor/linux.rs
@@ -66,9 +66,21 @@ impl Hypervisor {
                 return Err(anyhow!("Partition \"{}\" already exists", p.name))
                     .lev_typ(SystemError::PartitionConfig, ErrorLevel::ModuleInit);
             }
+
+            let mut veth: Vec<(String, String)> = Vec::with_capacity(p.veth.len());
+            for p in &p.veth {
+                let v: Vec<String> = p.split(":").map(|s| String::from(s)).collect();
+                if v.len() != 2 || v[0].len() < 1 || v[1].len() < 1 {
+                    return Err(anyhow!("veth pair {p} is malformatted"))
+                        .lev_typ(SystemError::PartitionConfig, ErrorLevel::ModuleInit);
+                }
+
+                veth.push((v[0].clone(), v[1].clone()));
+            }
+
             hv.partitions.insert(
                 p.name.clone(),
-                Partition::new(hv.cg.get_path(), p.clone(), &hv.sampling_channel)
+                Partition::new(hv.cg.get_path(), p.clone(), &hv.sampling_channel, veth)
                     .lev(ErrorLevel::ModuleInit)?,
             );
         }


### PR DESCRIPTION
This pull requests implements the feature to move n interfaces from the host to a partition. The interfaces do not get moved back to the host, after the execution was finished. I have abstracted the internals in a new module named `net` inside the `core` crate, that just makes use of the `ip(8)` command. In future, this can be replaced with native `netlink(7)`.

In order to move an interface, someone simply has to modify the config as follows:
```yaml
major_frame: 1s
partitions:
  - id: 0
    name: Foo
    duration: 10ms
    offset: 0ms
    period: 500ms
    image: target/x86_64-unknown-linux-musl/release/hello_part
    interfaces:
      - eth0
      - eth1
```