### PR TITLE
Prevent crash when logging many messages

### DIFF
--- a/core/src/ipc.rs
+++ b/core/src/ipc.rs
@@ -31,6 +31,7 @@ where
     T: Serialize,
 {
     /// Sends value alongside the IpcSender
+    /// This fails if the resource is temporarily not available.
     pub fn try_send(&self, value: &T) -> TypedResult<()> {
         self.socket
             .send(bincode::serialize(value).typ(SystemError::Panic)?.as_ref())

--- a/partition/src/apex.rs
+++ b/partition/src/apex.rs
@@ -5,6 +5,7 @@ use a653rs::bindings::*;
 use a653rs::prelude::{Name, SystemTime};
 use a653rs_linux_core::error::SystemError;
 use a653rs_linux_core::sampling::{SamplingDestination, SamplingSource};
+use nix::libc::EAGAIN;
 
 use crate::partition::ApexLinuxPartition;
 use crate::process::Process as LinuxProcess;
@@ -208,9 +209,16 @@ impl ApexErrorP4 for ApexLinuxPartition {
             return Err(ErrorReturnCode::InvalidParam);
         }
         if let Ok(msg) = std::str::from_utf8(message) {
-            SENDER
-                .try_send(&PartitionCall::Message(msg.to_string()))
-                .unwrap();
+            // Logging may fail temporarily, because the resource can not be written to (e.g. queue is full),
+            // but the API does not allow us any other return code than INVALID_PARAM.
+            if let Err(e) = SENDER.try_send(&PartitionCall::Message(msg.to_string())) {
+                if let Some(e) = e.source().downcast_ref::<std::io::Error>() {
+                    if e.raw_os_error() == Some(EAGAIN) {
+                        return Ok(());
+                    }
+                }
+                panic!("Failed to report application message: {}", e);
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
The logger of a partition process uses Unix domain sockets to write messages to the hypervisor process. This may fail temporarily, if the socket cannot receive any more messages. The APEX does not provide a status code for signaling this condition to the partition process and instead the way with dealing any error when writing to the logger was to panic inside the partition process.

This commit prevents a crash when the socket can temporarily not be written to and instead ignores the error. The tradeoff is that if the partition produces a great number of messages, some of them may not be logged.

This fixes #51 