### PR TITLE
examples: remove unused imports

### DIFF
--- a/examples/fuel_tank_simulation/Cargo.toml
+++ b/examples/fuel_tank_simulation/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 a653rs = { version = "0.2", features = ["macros"] }
-a653rs-postcard = { git = "https://github.com/DLR-FT/a653rs-postcard.git", branch = "main" }
 a653rs-linux-core = { path = "../../core" }
 a653rs-linux = { path = "../../partition" }
 serde = "1.0"
@@ -16,5 +15,4 @@ procfs = "0.14"
 log = "0"
 nix = "0.25"
 memmap2 = "0.5.5"
-humantime = "2.1"
 once_cell = "1.13"

--- a/examples/fuel_tank_simulation/src/main.rs
+++ b/examples/fuel_tank_simulation/src/main.rs
@@ -12,14 +12,8 @@ fn main() {
 
 #[partition(a653rs_linux::partition::ApexLinuxPartition)]
 mod hello {
-    use core::time::Duration;
-    use std::thread::sleep;
-
     use a653rs::prelude::SystemTime;
-    use a653rs_postcard::prelude::*;
-    use humantime::format_duration;
     use log::*;
-    use serde::{Deserialize, Serialize};
 
     #[sampling_in(name = "fuel_actuators", msg_size = "10KB", refresh_period = "20ms")]
     struct FuelActuators;


### PR DESCRIPTION
This commit removes unused imports in the `fuel_tank_simulation`, which currently trigger several warnings during the compilation.