### PR TITLE
Automatically wrap comments

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+wrap_comments = true

--- a/core/src/cgroup.rs
+++ b/core/src/cgroup.rs
@@ -414,7 +414,8 @@ mod tests {
 
         cg.rm().unwrap();
 
-        // TODO: Check if the previous PID still exists (although unstable because the OS may re-assign)
+        // TODO: Check if the previous PID still exists (although unstable
+        // because the OS may re-assign)
     }
 
     #[test]

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -4,13 +4,15 @@ use thiserror::Error;
 
 /// A Result containing a SystemError with its accompanying source
 pub type TypedResult<T> = Result<T, TypedError>;
-/// A Result containing a SystemError with its accompanying error and time window
+/// A Result containing a SystemError with its accompanying error and time
+/// window
 // TODO: Consider merging these two types by making level an Option.
 pub type LeveledResult<T> = Result<T, LeveledError>;
 
 /// A low-level error issued by the operating system
 ///
-/// This implementation is custom. Do not confuse it with the traditional unix errnos.
+/// This implementation is custom. Do not confuse it with the traditional unix
+/// errnos.
 // TODO: Why can't we just use traditional unix errnos? The anyhow messages should be
 // concrete enough.
 #[derive(Error, Debug, Serialize, Deserialize, Clone, Copy)]

--- a/core/src/fd.rs
+++ b/core/src/fd.rs
@@ -15,7 +15,8 @@ use crate::error::{ResultExt, SystemError, TypedError, TypedResult};
 
 #[derive(Debug)]
 /// The fundamental error type for this crate
-// TODO: Consider replacing it with a normal TypedError and using TimeDurationExceeded instead
+// TODO: Consider replacing it with a normal TypedError and using
+// TimeDurationExceeded instead
 pub enum PidWaitError {
     /// A timeout has a occurred
     Timeout,
@@ -44,8 +45,8 @@ impl PidFd {
 
         loop {
             // The second argument to Poller::modify() is totally valid and correct, due to
-            // epoll(2) internals, which demand providing a "user data variable" -- a feature
-            // that we make no use of.
+            // epoll(2) internals, which demand providing a "user data variable" -- a
+            // feature that we make no use of.
             poller
                 .modify(self.0.as_raw_fd(), Event::readable(42))
                 .map_err(anyhow::Error::from)
@@ -87,7 +88,8 @@ impl TryFrom<Pid> for PidFd {
                 .typ(SystemError::Panic)?
         };
         if pidfd < 0 {
-            // TODO: pidfd will be -1 in that case. Printing this is not useful. Access errno instead.
+            // TODO: pidfd will be -1 in that case. Printing this is not useful. Access
+            // errno instead.
             return Err(anyhow!("Error getting pidfd from {value}. {pidfd}"))
                 .typ(SystemError::Panic);
         }

--- a/core/src/file.rs
+++ b/core/src/file.rs
@@ -73,7 +73,8 @@ impl<T: Send + Clone + Sized> TempFile<T> {
         self.fd
     }
 
-    /// Writes value to the TempFile (overwrites existing data, but does not clean)
+    /// Writes value to the TempFile (overwrites existing data, but does not
+    /// clean)
     // TODO: Consider deleting the previous data?
     pub fn write(&self, value: &T) -> TypedResult<()> {
         // TODO: Use an approach without unsafe
@@ -92,7 +93,8 @@ impl<T: Send + Clone + Sized> TempFile<T> {
         let mut data = MaybeUninit::<T>::uninit();
         let bytes_required = size_of::<T>();
 
-        // the mut buf binding to the data in the MaybeUninit allows writing to the type byte-wise
+        // the mut buf binding to the data in the MaybeUninit allows writing to the type
+        // byte-wise
         let buf =
             unsafe { std::slice::from_raw_parts_mut(data.as_mut_ptr() as *mut u8, size_of::<T>()) };
 

--- a/core/src/ipc.rs
+++ b/core/src/ipc.rs
@@ -66,7 +66,8 @@ where
             .typ(SystemError::Panic)
     }
 
-    /// Reads a single instance of T from the IpcReceiver but fail after duration
+    /// Reads a single instance of T from the IpcReceiver but fail after
+    /// duration
     pub fn try_recv_timeout(&self, duration: Duration) -> TypedResult<Option<T>> {
         let poller = Poller::new().typ(SystemError::Panic)?;
         poller

--- a/examples/fuel_tank_simulation/src/main.rs
+++ b/examples/fuel_tank_simulation/src/main.rs
@@ -49,7 +49,9 @@ mod hello {
     fn periodic(ctx: periodic::Context) {
         info!("Start Aperiodic");
 
-        // TODO implement cascading flow, filling one f32 takes from a slice of f32, starting from the right most element in the slice. After consumption move all fuel as far as possible to the left.
+        // TODO implement cascading flow, filling one f32 takes from a slice of f32,
+        // starting from the right most element in the slice. After consumption move all
+        // fuel as far as possible to the left.
 
         loop {
             // Step 1: get control commands

--- a/hypervisor/src/hypervisor/linux.rs
+++ b/hypervisor/src/hypervisor/linux.rs
@@ -167,8 +167,8 @@ impl Drop for Hypervisor {
             "moving own process to previous cgroup {:?}",
             self.prev_cg.as_path()
         );
-        // Using unwrap in this context is probably safe, as a failure in import_root requires that
-        // the cgroup must have been deleted externally
+        // Using unwrap in this context is probably safe, as a failure in import_root
+        // requires that the cgroup must have been deleted externally
         if let Err(e) = CGroup::import_root(&self.prev_cg)
             .unwrap()
             .mv(nix::unistd::getpid())

--- a/hypervisor/src/hypervisor/partition.rs
+++ b/hypervisor/src/hypervisor/partition.rs
@@ -152,7 +152,8 @@ impl Run {
 
         let (call_tx, call_rx) = channel_pair::<PartitionCall>()?;
 
-        // TODO add a `::new(warm_start: bool)->Self` function to `OperatingMode`, use it here
+        // TODO add a `::new(warm_start: bool)->Self` function to `OperatingMode`, use
+        // it here
         let mode = if warm_start {
             OperatingMode::WarmStart
         } else {

--- a/hypervisor/src/hypervisor/process.rs
+++ b/hypervisor/src/hypervisor/process.rs
@@ -1,4 +1,5 @@
-//const PROCESSES: Arc<RwLock<HashMap<ProcessId, Process>>> = Arc::new(RwLock::new(HashMap::new()));
+//const PROCESSES: Arc<RwLock<HashMap<ProcessId, Process>>> =
+// Arc::new(RwLock::new(HashMap::new()));
 
 #[derive(Debug)]
 pub struct Process;

--- a/hypervisor/src/hypervisor/process.rs
+++ b/hypervisor/src/hypervisor/process.rs
@@ -1,5 +1,2 @@
-//const PROCESSES: Arc<RwLock<HashMap<ProcessId, Process>>> =
-// Arc::new(RwLock::new(HashMap::new()));
-
 #[derive(Debug)]
 pub struct Process;

--- a/hypervisor/src/hypervisor/scheduler.rs
+++ b/hypervisor/src/hypervisor/scheduler.rs
@@ -43,20 +43,6 @@ impl<'a> PartitionTimeWindow<'a> {
         PartitionTimeWindow { base, run, timeout }
     }
 
-    #[rustfmt::skip]
-    // // Initializes a Partition if it wasn't initialized before
-    // fn init_run<'b>(base: &'_ Base, run: &'b mut Option<Run>) -> TypedResult<&'b
-    // mut Run> {     match run {
-    //         Some(run) => Ok(run),
-    //         run @ None => {
-    //             let new_run = Run::new(base, StartCondition::NormalStart,
-    // false).typ(SystemError::PartitionInit)?;
-    // run.get_or_insert(new_run);             // Unwrap can not fail because we
-    // just set it to a value             Ok(run.as_mut().unwrap())
-    //         }
-    //     }
-    // }
-
     fn handle_part_err(&mut self, res: TypedResult<()>) -> LeveledResult<()> {
         debug!("Partition \"{}\" received err: {res:?}", self.base.name());
         if let Err(err) = res.as_ref() {

--- a/hypervisor/src/hypervisor/scheduler.rs
+++ b/hypervisor/src/hypervisor/scheduler.rs
@@ -43,18 +43,19 @@ impl<'a> PartitionTimeWindow<'a> {
         PartitionTimeWindow { base, run, timeout }
     }
 
-    ///// Initializes a Partition if it wasn't initialized before
-    //fn init_run<'b>(base: &'_ Base, run: &'b mut Option<Run>) -> TypedResult<&'b mut Run> {
-    //    match run {
-    //        Some(run) => Ok(run),
-    //        run @ None => {
-    //            let new_run = Run::new(base, StartCondition::NormalStart, false).typ(SystemError::PartitionInit)?;
-    //            run.get_or_insert(new_run);
-    //            // Unwrap can not fail because we just set it to a value
-    //            Ok(run.as_mut().unwrap())
-    //        }
-    //    }
-    //}
+    #[rustfmt::skip]
+    // // Initializes a Partition if it wasn't initialized before
+    // fn init_run<'b>(base: &'_ Base, run: &'b mut Option<Run>) -> TypedResult<&'b
+    // mut Run> {     match run {
+    //         Some(run) => Ok(run),
+    //         run @ None => {
+    //             let new_run = Run::new(base, StartCondition::NormalStart,
+    // false).typ(SystemError::PartitionInit)?;
+    // run.get_or_insert(new_run);             // Unwrap can not fail because we
+    // just set it to a value             Ok(run.as_mut().unwrap())
+    //         }
+    //     }
+    // }
 
     fn handle_part_err(&mut self, res: TypedResult<()>) -> LeveledResult<()> {
         debug!("Partition \"{}\" received err: {res:?}", self.base.name());
@@ -78,7 +79,8 @@ impl<'a> PartitionTimeWindow<'a> {
             debug!("Handling: {err:?}");
             debug!("Apply Partition Recovery Action: {action:?}");
 
-            // TODO do not unwrap/expect these errors. Maybe raise Module Level PartitionInit Error?
+            // TODO do not unwrap/expect these errors. Maybe raise Module Level
+            // PartitionInit Error?
             match action {
                 a653rs_linux_core::health::PartitionRecoveryAction::Idle => self
                     .run
@@ -135,8 +137,9 @@ impl<'a> PartitionTimeWindow<'a> {
         if let OperatingMode::Idle = self.run.mode() {
             sleep(self.timeout.remaining_time());
         } else {
-            // Else we are in either a start mode or normal mode (post periodic/mid aperiodic time frame)
-            // Either-way we are supposed to unfreeze the partition
+            // Else we are in either a start mode or normal mode (post periodic/mid
+            // aperiodic time frame) Either-way we are supposed to unfreeze the
+            // partition
             self.base.unfreeze()?;
 
             let mut leftover = self.timeout.remaining_time();
@@ -291,8 +294,10 @@ impl PeriodicPoller {
                     // got a call events
                     Self::RECEIVER_ID => {
                         // Re-sub the readable event
-                        // This will result in the event instantly being ready again should we have something to read,
-                        // but that is better than accidentally missing an event (at the expense of one extra loop per receive)
+                        // This will result in the event instantly being ready again should we have
+                        // something to read, but that is better than
+                        // accidentally missing an event (at the expense of one extra loop per
+                        // receive)
                         self.poll
                             .modify(
                                 run.receiver().as_raw_fd(),

--- a/partition/src/apex.rs
+++ b/partition/src/apex.rs
@@ -209,8 +209,9 @@ impl ApexErrorP4 for ApexLinuxPartition {
             return Err(ErrorReturnCode::InvalidParam);
         }
         if let Ok(msg) = std::str::from_utf8(message) {
-            // Logging may fail temporarily, because the resource can not be written to (e.g. queue is full),
-            // but the API does not allow us any other return code than INVALID_PARAM.
+            // Logging may fail temporarily, because the resource can not be written to
+            // (e.g. queue is full), but the API does not allow us any other
+            // return code than INVALID_PARAM.
             if let Err(e) = SENDER.try_send(&PartitionCall::Message(msg.to_string())) {
                 if let Some(e) = e.source().downcast_ref::<std::io::Error>() {
                     if e.raw_os_error() == Some(EAGAIN) {

--- a/partition/src/process.rs
+++ b/partition/src/process.rs
@@ -191,6 +191,7 @@ impl Process {
         safemem::write_bytes(stack, 0);
         let cbk = Box::new(move || {
             // TODO
+            #[rustfmt::skip]
             //setrlimit(Resource::RLIMIT_STACK, stack_size - 2000, stack_size - 2000).unwrap();
 
             let cg = self.cg().unwrap();

--- a/partition/src/process.rs
+++ b/partition/src/process.rs
@@ -190,10 +190,6 @@ impl Process {
         //let stack_size = self.attr.stack_size as u64;
         safemem::write_bytes(stack, 0);
         let cbk = Box::new(move || {
-            // TODO
-            #[rustfmt::skip]
-            //setrlimit(Resource::RLIMIT_STACK, stack_size - 2000, stack_size - 2000).unwrap();
-
             let cg = self.cg().unwrap();
             cg.mv(getpid()).unwrap();
             (self.attr.entry_point)();


### PR DESCRIPTION
Adds automatic wrapping of comments using rustfmt. One concern is commented out code, which will be wrapped and there is no way of disabling this currently. https://github.com/rust-lang/rustfmt/issues/5727

We should not have commented out code anyway, because this is considered bad practice if you believe in Clean Code.