### PR TITLE
core: change channel configuration

### DIFF
--- a/core/src/channel.rs
+++ b/core/src/channel.rs
@@ -8,16 +8,20 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SamplingChannelConfig {
-    pub name: String,
     #[serde(deserialize_with = "de_size_str")]
     pub msg_size: ByteSize,
     pub source: PortConfig,
     pub destination: HashSet<PortConfig>,
 }
 
+impl SamplingChannelConfig {
+    pub fn name(&self) -> &str {
+        &self.source.port
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct QueuingChannelConfig {
-    pub name: String,
     #[serde(deserialize_with = "de_size_str")]
     pub msg_size: ByteSize,
     pub msg_num: usize,
@@ -25,10 +29,22 @@ pub struct QueuingChannelConfig {
     pub destination: PortConfig,
 }
 
+impl QueuingChannelConfig {
+    pub fn name(&self) -> &str {
+        &self.source.port
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Hash, PartialEq, Eq)]
 pub struct PortConfig {
     pub partition: String,
     pub port: String,
+}
+
+impl PortConfig {
+    pub fn name(&self) -> String {
+        format!("{}:{}", self.partition, self.port)
+    }
 }
 
 fn de_size_str<'de, D>(de: D) -> Result<ByteSize, D::Error>

--- a/core/src/channel.rs
+++ b/core/src/channel.rs
@@ -11,8 +11,8 @@ pub struct SamplingChannelConfig {
     pub name: String,
     #[serde(deserialize_with = "de_size_str")]
     pub msg_size: ByteSize,
-    pub source: String,
-    pub destination: HashSet<String>,
+    pub source: PortConfig,
+    pub destination: HashSet<PortConfig>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -21,8 +21,14 @@ pub struct QueuingChannelConfig {
     #[serde(deserialize_with = "de_size_str")]
     pub msg_size: ByteSize,
     pub msg_num: usize,
-    pub source: String,
-    pub destination: String,
+    pub source: PortConfig,
+    pub destination: PortConfig,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Hash, PartialEq, Eq)]
+pub struct PortConfig {
+    pub partition: String,
+    pub port: String,
 }
 
 fn de_size_str<'de, D>(de: D) -> Result<ByteSize, D::Error>

--- a/examples/fuel_tank.yaml
+++ b/examples/fuel_tank.yaml
@@ -14,7 +14,6 @@ partitions:
     period: 20ms
 channel:
   - !Sampling
-    name: fuel_sensors
     msg_size: 10KB
     source:
       partition: fuel_tank_simulation
@@ -23,7 +22,6 @@ channel:
       - partition: fuel_tank_controller
         port: fuel_sensors
   - !Sampling
-    name: fuel_actuators
     msg_size: 10KB
     source:
       partition: fuel_tank_controller

--- a/examples/fuel_tank.yaml
+++ b/examples/fuel_tank.yaml
@@ -10,7 +10,7 @@ partitions:
     name: fuel_tank_controller
     offset: 10ms
     duration: 10ms
-    image: fuel_tank_simulation # TODO make this the controller
+    image: fuel_tank_controller
     period: 20ms
 channel:
   - !Sampling

--- a/examples/fuel_tank.yaml
+++ b/examples/fuel_tank.yaml
@@ -16,12 +16,18 @@ channel:
   - !Sampling
     name: fuel_sensors
     msg_size: 10KB
-    source: fuel_tank_simulation
+    source:
+      partition: fuel_tank_simulation
+      port: fuel_sensors
     destination:
-      - fuel_tank_controller
+      - partition: fuel_tank_controller
+        port: fuel_sensors
   - !Sampling
     name: fuel_actuators
     msg_size: 10KB
-    source: fuel_tank_controller
+    source:
+      partition: fuel_tank_controller
+      port: fuel_actuators
     destination:
-      - fuel_tank_simulation
+      - partition: fuel_tank_simulation
+        port: fuel_actuators

--- a/examples/hello_part.yaml
+++ b/examples/hello_part.yaml
@@ -16,6 +16,9 @@ channel:
   - !Sampling
     name: Hello
     msg_size: 10KB
-    source: Foo
+    source:
+      partition: Foo
+      port: Hello
     destination:
-      - Bar
+      - partition: Bar
+        port: Hello

--- a/examples/ping.yaml
+++ b/examples/ping.yaml
@@ -16,12 +16,18 @@ channel:
   - !Sampling
     name: ping_request
     msg_size: 16B
-    source: ping_client
+    source:
+      partition: ping_client
+      port: PingReq
     destination:
-      - ping_server
+      - partition: ping_server
+        port: ping_request
   - !Sampling
     name: ping_response
     msg_size: 32B
-    source: ping_server
+    source:
+      partition: ping_server
+      port: ping_response
     destination:
-      - ping_client
+      - partition: ping_client
+        port: PingRes

--- a/examples/ping.yaml
+++ b/examples/ping.yaml
@@ -14,7 +14,6 @@ partitions:
     image: ping_server
 channel:
   - !Sampling
-    name: ping_request
     msg_size: 16B
     source:
       partition: ping_client
@@ -23,7 +22,6 @@ channel:
       - partition: ping_server
         port: ping_request
   - !Sampling
-    name: ping_response
     msg_size: 32B
     source:
       partition: ping_server

--- a/examples/ping_client/src/main.rs
+++ b/examples/ping_client/src/main.rs
@@ -15,10 +15,10 @@ mod ping_client {
     use core::time::Duration;
     use log::{info, warn};
 
-    #[sampling_out(name = "ping_request", msg_size = "16B")]
+    #[sampling_out(name = "PingReq", msg_size = "16B")]
     struct PingRequest;
 
-    #[sampling_in(name = "ping_response", msg_size = "32B", refresh_period = "10s")]
+    #[sampling_in(name = "PingRes", msg_size = "32B", refresh_period = "10s")]
     struct PingResponse;
 
     #[start(cold)]

--- a/hypervisor/src/hypervisor/config.rs
+++ b/hypervisor/src/hypervisor/config.rs
@@ -37,9 +37,12 @@
 //!   - !Sampling
 //!     name: Hello
 //!     msg_size: 10KB
-//!     source: Foo
+//!     source:
+//!       partition: Foo
+//!       port: HelloSend
 //!     destination:
-//!       - Bar
+//!       - partition: Bar
+//!         port: Hello
 //! # ";
 //! # serde_yaml::from_str::<Config>(yaml).unwrap();
 //! ```

--- a/hypervisor/src/hypervisor/config.rs
+++ b/hypervisor/src/hypervisor/config.rs
@@ -35,7 +35,6 @@
 //!     period: 1s
 //! channel:
 //!   - !Sampling
-//!     name: Hello
 //!     msg_size: 10KB
 //!     source:
 //!       partition: Foo

--- a/hypervisor/src/hypervisor/linux.rs
+++ b/hypervisor/src/hypervisor/linux.rs
@@ -80,14 +80,13 @@ impl Hypervisor {
         match channel {
             Channel::Queuing(_) => todo!(),
             Channel::Sampling(s) => {
-                if self.sampling_channel.contains_key(&s.name) {
-                    return Err(anyhow!("Sampling Channel \"{}\" already exists", s.name))
+                if self.sampling_channel.contains_key(&s.name().to_string()) {
+                    return Err(anyhow!("Sampling Channel \"{}\" already exists", s.name()))
                         .lev_typ(SystemError::PartitionConfig, ErrorLevel::ModuleInit);
                 }
 
                 let sampling = Sampling::try_from(s).lev(ErrorLevel::ModuleInit)?;
-                self.sampling_channel
-                    .insert(sampling.name().to_string(), sampling);
+                self.sampling_channel.insert(sampling.name(), sampling);
             }
         }
 


### PR DESCRIPTION
The hypervisor configuration of a channel now identifies the source and destination of a sampling or queuing channel using the name of the connected partition and the name of the port inside the partition.

Closes #93