### PR TITLE
Update unsafe-libyaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,9 +1330,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "utf8parse"

--- a/core/src/fd.rs
+++ b/core/src/fd.rs
@@ -61,8 +61,7 @@ impl PidFd {
                 Ok(_) => return Ok(()),
                 Err(e) => {
                     if e.kind() != ErrorKind::Interrupted {
-                        return Err(e)
-                            .map_err(anyhow::Error::from)
+                        return Err(anyhow::Error::from(e))
                             .typ(SystemError::Panic)
                             .map_err(PidWaitError::Err);
                     }

--- a/hypervisor/src/hypervisor/partition.rs
+++ b/hypervisor/src/hypervisor/partition.rs
@@ -382,10 +382,9 @@ impl Run {
     }
 
     pub fn periodic_events(&self) -> TypedResult<OwnedFd> {
-        OwnedFd::try_from(
-            std::fs::File::open(self.cgroup_periodic.get_events_path()).typ(SystemError::CGroup)?,
-        )
-        .typ(SystemError::CGroup)
+        Ok(std::fs::File::open(self.cgroup_periodic.get_events_path())
+            .typ(SystemError::CGroup)?
+            .into())
     }
 
     pub fn is_periodic_frozen(&self) -> TypedResult<bool> {

--- a/hypervisor/src/hypervisor/syscall.rs
+++ b/hypervisor/src/hypervisor/syscall.rs
@@ -147,7 +147,7 @@ mod tests {
             {
                 let fds = [requ_fd.get_fd(), resp_fd.get_fd(), event_fd];
                 let cmsg = [ControlMessage::ScmRights(&fds)];
-                let buffer = (0 as u64).to_be_bytes();
+                let buffer = 0_u64.to_be_bytes();
                 let iov = [IoSlice::new(buffer.as_slice())];
                 sendmsg::<()>(requester, &iov, &cmsg, MsgFlags::empty(), None).unwrap();
             }

--- a/hypervisor/src/lib.rs
+++ b/hypervisor/src/lib.rs
@@ -170,7 +170,7 @@ mod test {
     fn problem_manual() -> TypedResult<()> {
         let extra_info = "problem";
         let problem = anyhow!("a {extra_info} description");
-        return Err(TypedError::new(SystemError::Panic, problem));
+        Err(TypedError::new(SystemError::Panic, problem))
     }
 
     fn problem_macro() -> TypedResult<()> {

--- a/partition/src/apex.rs
+++ b/partition/src/apex.rs
@@ -62,7 +62,7 @@ impl ApexProcessP4 for ApexLinuxPartition {
     ) -> Result<ProcessId, ErrorReturnCode> {
         // TODO do not unwrap both
         // Check current State (only allowed in warm and cold start)
-        let attr = attributes.clone().try_into().unwrap();
+        let attr = attributes.clone().into();
         Ok(LinuxProcess::create(attr).unwrap())
     }
 

--- a/partition/src/process.rs
+++ b/partition/src/process.rs
@@ -86,10 +86,10 @@ impl Process {
 
         // Files for dropping fd
         let mut fds = Vec::new();
-        let activated = TempFile::create(&format!("state_{name}")).lev(ErrorLevel::Partition)?;
+        let activated = TempFile::create(format!("state_{name}")).lev(ErrorLevel::Partition)?;
         fds.push(unsafe { OwnedFd::from_raw_fd(activated.fd()) });
         activated.write(&false).lev(ErrorLevel::Partition)?;
-        let pid = TempFile::create(&format!("pid_{name}")).lev(ErrorLevel::Partition)?;
+        let pid = TempFile::create(format!("pid_{name}")).lev(ErrorLevel::Partition)?;
         fds.push(unsafe { OwnedFd::from_raw_fd(pid.fd()) });
 
         let process = Self {


### PR DESCRIPTION
> Affected versions allocate memory using the alignment of usize and write data to it of type u64, without using core::ptr::write_unaligned. In platforms with sub-64bit alignment for usize (including wasm32 and x86) these writes are insufficiently aligned some of the time.
>
> If using an ordinary optimized standard library, the bug exhibits Undefined Behavior so may or may not behave in any sensible way, depending on optimization settings and hardware and other things. If using a Rust standard library built with debug assertions enabled, the bug manifests deterministically in a crash (non-unwinding panic) saying "ptr::write requires that the pointer argument is aligned and non-null".
>
> No 64-bit platform is impacted by the bug.
>
> The flaw was corrected by allocating with adequately high alignment on all
> platforms.