### PR TITLE
New scheduler structure & other minor refactorings

### DIFF
--- a/examples/fuel_tank_controller/src/main.rs
+++ b/examples/fuel_tank_controller/src/main.rs
@@ -2,8 +2,9 @@
 
 use a653rs::partition;
 use a653rs::prelude::PartitionExt;
-use a653rs_linux::partition::ApexLogger;
 use log::LevelFilter;
+
+use a653rs_linux::partition::ApexLogger;
 
 fn main() {
     ApexLogger::install_panic_hook();
@@ -14,7 +15,6 @@ fn main() {
 
 #[partition(a653rs_linux::partition::ApexLinuxPartition)]
 mod hello {
-
     use a653rs::prelude::SystemTime;
 
     #[sampling_in(name = "fuel_sensors", msg_size = "10KB", refresh_period = "10s")]
@@ -22,12 +22,27 @@ mod hello {
 
     #[sampling_out(name = "fuel_actuators", msg_size = "10KB")]
     struct FuelActuators;
-
     #[start(cold)]
-    fn cold_start(_ctx: start::Context) {}
+    fn cold_start(mut ctx: start::Context) {
+        ctx.create_periodic().unwrap().start().unwrap();
+    }
 
     #[start(warm)]
     fn warm_start(ctx: start::Context) {
         cold_start(ctx)
+    }
+
+    #[periodic(
+        period = "0ms",
+        time_capacity = "Infinite",
+        stack_size = "100KB",
+        base_priority = 1,
+        deadline = "Soft"
+    )]
+    fn periodic(ctx: periodic::Context) {
+        loop {
+            // Empty for now
+            ctx.periodic_wait().unwrap();
+        }
     }
 }

--- a/hypervisor/src/hypervisor/mod.rs
+++ b/hypervisor/src/hypervisor/mod.rs
@@ -13,7 +13,7 @@ use a653rs_linux_core::sampling::Sampling;
 
 use crate::hypervisor::config::{Channel, Config};
 use crate::hypervisor::partition::Partition;
-use crate::hypervisor::scheduler::Timeout;
+use crate::hypervisor::scheduler::{ScheduledTimeframe, Timeout};
 
 pub mod config;
 pub mod partition;
@@ -28,7 +28,7 @@ pub static SYSTEM_START_TIME: OnceCell<TempFile<Instant>> = OnceCell::new();
 pub struct Hypervisor {
     cg: CGroup,
     major_frame: Duration,
-    schedule: Vec<(Duration, Duration, String)>,
+    schedule: Vec<ScheduledTimeframe>,
     partitions: HashMap<String, Partition>,
     sampling_channel: HashMap<String, Sampling>,
     prev_cg: PathBuf,
@@ -145,13 +145,18 @@ impl Hypervisor {
                 _ => {}
             }
 
-            for (target_start, target_stop, partition_name) in &self.schedule {
-                sleep(target_start.saturating_sub(frame_start.elapsed()));
+            for ScheduledTimeframe {
+                start,
+                end,
+                partition_name,
+            } in &self.schedule
+            {
+                sleep(start.saturating_sub(frame_start.elapsed()));
 
-                self.partitions.get_mut(partition_name).unwrap().run(
-                    &mut self.sampling_channel,
-                    Timeout::new(frame_start, *target_stop),
-                )?;
+                self.partitions
+                    .get_mut(partition_name)
+                    .unwrap()
+                    .run(&mut self.sampling_channel, Timeout::new(frame_start, *end))?;
             }
             sleep(self.major_frame.saturating_sub(frame_start.elapsed()));
 

--- a/hypervisor/src/hypervisor/partition.rs
+++ b/hypervisor/src/hypervisor/partition.rs
@@ -703,7 +703,9 @@ impl Partition {
     }
 
     pub fn run_post_timeframe(&mut self, sampling_channels: &mut HashMap<String, Sampling>) {
-        // TODO remove because a base freeze is not necessary here, as all run_* methods should freeze base themself after execution. Before removal of this, check all run_* methods.
+        // TODO remove because a base freeze is not necessary here, as all run_* methods
+        // should freeze base themself after execution. Before removal of this, check
+        // all run_* methods.
         let _ = self.base.freeze();
 
         for (name, _) in self
@@ -716,8 +718,9 @@ impl Partition {
         }
     }
 
-    /// Executes the periodic process for a maximum duration specified through the `timeout` parameter.
-    /// Returns whether the periodic process exists and was run.
+    /// Executes the periodic process for a maximum duration specified through
+    /// the `timeout` parameter. Returns whether the periodic process exists
+    /// and was run.
     pub fn run_periodic_process(&mut self, timeout: Timeout) -> TypedResult<bool> {
         match self.run.unfreeze_periodic() {
             Ok(true) => {}

--- a/hypervisor/src/hypervisor/partition.rs
+++ b/hypervisor/src/hypervisor/partition.rs
@@ -4,7 +4,8 @@ use std::net::{TcpStream, UdpSocket};
 use std::os::unix::prelude::{AsRawFd, FromRawFd, OwnedFd, PermissionsExt, RawFd};
 use std::path::{self, Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
 
 use a653rs::bindings::PortDirection;
 use a653rs::prelude::{OperatingMode, StartCondition};
@@ -14,15 +15,16 @@ use itertools::Itertools;
 use nix::mount::{mount, umount2, MntFlags, MsFlags};
 use nix::sys::socket::{self, bind, AddressFamily, SockFlag, SockType, UnixAddr};
 use nix::unistd::{chdir, close, pivot_root, setgid, setuid, Gid, Pid, Uid};
+use polling::{Event, Poller};
 use procfs::process::Process;
 use tempfile::{tempdir, TempDir};
 
 use a653rs_linux_core::cgroup::CGroup;
 use a653rs_linux_core::error::{
-    ErrorLevel, LeveledResult, ResultExt, SystemError, TypedResult, TypedResultExt,
+    ErrorLevel, LeveledResult, ResultExt, SystemError, TypedError, TypedResult, TypedResultExt,
 };
 use a653rs_linux_core::file::TempFile;
-use a653rs_linux_core::health::PartitionHMTable;
+use a653rs_linux_core::health::{ModuleRecoveryAction, PartitionHMTable, RecoveryAction};
 use a653rs_linux_core::health_event::PartitionCall;
 use a653rs_linux_core::ipc::{channel_pair, io_pair, IoReceiver, IoSender, IpcReceiver};
 use a653rs_linux_core::partition::{PartitionConstants, SamplingConstant};
@@ -34,7 +36,7 @@ use crate::hypervisor::SYSTEM_START_TIME;
 use crate::problem;
 
 use super::config::PosixSocket;
-use super::scheduler::{PartitionTimeWindow, Timeout};
+use super::scheduler::Timeout;
 
 #[derive(Debug, Clone, Copy)]
 pub enum TransitionAction {
@@ -674,25 +676,8 @@ impl Partition {
         }
     }
 
-    pub fn run(
-        &mut self,
-        sampling: &mut HashMap<String, Sampling>,
-        timeout: Timeout,
-    ) -> LeveledResult<()> {
-        PartitionTimeWindow::new(&self.base, &mut self.run, timeout).run()?;
-        // TODO Error handling and freeze if err
-        self.base.freeze().lev(ErrorLevel::Partition)?;
-
-        for (name, _) in self
-            .base
-            .sampling_channel
-            .iter()
-            .filter(|(_, s)| s.dir == PortDirection::Source)
-        {
-            sampling.get_mut(name).unwrap().swap();
-        }
-
-        Ok(())
+    pub fn get_base_run(&mut self) -> (&Base, &mut Run) {
+        (&self.base, &mut self.run)
     }
 
     //fn idle_transition(mut self) -> Result<()> {
@@ -715,6 +700,221 @@ impl Partition {
 
     pub(crate) fn rm(self) -> TypedResult<()> {
         self.base.cgroup.rm().typ(SystemError::CGroup)
+    }
+
+    pub fn run_post_timeframe(&mut self, sampling_channels: &mut HashMap<String, Sampling>) {
+        // TODO remove because a base freeze is not necessary here, as all run_* methods should freeze base themself after execution. Before removal of this, check all run_* methods.
+        let _ = self.base.freeze();
+
+        for (name, _) in self
+            .base
+            .sampling_channel
+            .iter()
+            .filter(|(_, s)| s.dir == PortDirection::Source)
+        {
+            sampling_channels.get_mut(name).unwrap().swap();
+        }
+    }
+
+    /// Executes the periodic process for a maximum duration specified through the `timeout` parameter.
+    /// Returns whether the periodic process exists and was run.
+    pub fn run_periodic_process(&mut self, timeout: Timeout) -> TypedResult<bool> {
+        match self.run.unfreeze_periodic() {
+            Ok(true) => {}
+            other => return other,
+        }
+
+        let mut poller = PeriodicPoller::new(&self.run)?;
+
+        self.base.unfreeze()?;
+
+        while timeout.has_time_left() {
+            let event = poller.wait_timeout(&mut self.run, timeout)?;
+            match &event {
+                PeriodicEvent::Timeout => {}
+                PeriodicEvent::Frozen => {
+                    self.base.freeze()?;
+
+                    return Ok(true);
+                }
+                // TODO Error Handling with HM
+                PeriodicEvent::Call(e @ PartitionCall::Error(se)) => {
+                    e.print_partition_log(self.base.name());
+                    match self.base.part_hm().try_action(*se) {
+                        Some(RecoveryAction::Module(ModuleRecoveryAction::Ignore)) => {}
+                        Some(_) => {
+                            return Err(TypedError::new(*se, anyhow!("Received Partition Error")))
+                        }
+                        None => {
+                            return Err(TypedError::new(
+                                SystemError::Panic,
+                                anyhow!(
+                                "Could not get recovery action for requested partition error: {se}"
+                            ),
+                            ))
+                        }
+                    };
+                }
+                PeriodicEvent::Call(c @ PartitionCall::Message(_)) => {
+                    c.print_partition_log(self.base.name())
+                }
+                PeriodicEvent::Call(PartitionCall::Transition(mode)) => {
+                    // Only exit run_periodic, if we changed our mode
+                    if self.run.handle_transition(&self.base, *mode)?.is_some() {
+                        return Ok(true);
+                    }
+                }
+            }
+        }
+
+        // TODO being here means that we exceeded the timeout
+        // So we should return a SystemError stating that the time was exceeded
+        Ok(true)
+    }
+
+    pub fn run_aperiodic_process(&mut self, timeout: Timeout) -> TypedResult<bool> {
+        match self.run.unfreeze_aperiodic() {
+            Ok(true) => {}
+            other => return other,
+        }
+
+        // Did we even need to unfreeze aperiodic?
+        self.base.unfreeze()?;
+
+        while timeout.has_time_left() {
+            match &self
+                .run
+                .receiver()
+                .try_recv_timeout(timeout.remaining_time())?
+            {
+                Some(m @ PartitionCall::Message(_)) => m.print_partition_log(self.base.name()),
+                Some(e @ PartitionCall::Error(se)) => {
+                    e.print_partition_log(self.base.name());
+                    match self.base.part_hm().try_action(*se) {
+                        Some(RecoveryAction::Module(ModuleRecoveryAction::Ignore)) => {}
+                        Some(_) => {
+                            return Err(TypedError::new(*se, anyhow!("Received Partition Error")))
+                        }
+                        None => {
+                            return Err(TypedError::new(
+                                SystemError::Panic,
+                                anyhow!(
+                                "Could not get recovery action for requested partition error: {se}"
+                            ),
+                            ))
+                        }
+                    };
+                }
+                Some(t @ PartitionCall::Transition(mode)) => {
+                    // In case of a transition to idle, just sleep. Do not care for the rest
+                    t.print_partition_log(self.base.name());
+                    if let Some(OperatingMode::Idle) =
+                        self.run.handle_transition(&self.base, *mode)?
+                    {
+                        sleep(timeout.remaining_time());
+                        return Ok(true);
+                    }
+                }
+                None => {}
+            }
+        }
+
+        self.run.freeze_aperiodic()?;
+
+        Ok(true)
+    }
+
+    /// Currently the same as run_aperiodic
+    pub fn run_start(&mut self, timeout: Timeout, _warm_start: bool) -> TypedResult<()> {
+        self.base.unfreeze()?;
+
+        while timeout.has_time_left() {
+            match &self
+                .run
+                .receiver()
+                .try_recv_timeout(timeout.remaining_time())?
+            {
+                Some(m @ PartitionCall::Message(_)) => m.print_partition_log(self.base.name()),
+                Some(e @ PartitionCall::Error(se)) => {
+                    e.print_partition_log(self.base.name());
+                    match self.base.part_hm().try_action(*se) {
+                        Some(RecoveryAction::Module(ModuleRecoveryAction::Ignore)) => {}
+                        Some(_) => {
+                            return Err(TypedError::new(*se, anyhow!("Received Partition Error")))
+                        }
+                        None => {
+                            return Err(TypedError::new(
+                                SystemError::Panic,
+                                anyhow!(
+                                "Could not get recovery action for requested partition error: {se}"
+                            ),
+                            ))
+                        }
+                    };
+                }
+                Some(t @ PartitionCall::Transition(mode)) => {
+                    // In case of a transition to idle, just sleep. Do not care for the rest
+                    t.print_partition_log(self.base.name());
+                    if let Some(OperatingMode::Idle) =
+                        self.run.handle_transition(&self.base, *mode)?
+                    {
+                        sleep(timeout.remaining_time());
+                        return Ok(());
+                    }
+                }
+                None => {}
+            }
+        }
+
+        self.base.freeze()
+    }
+
+    /// Handles an error that occurred during self.run_* methods.
+    pub fn handle_error(&mut self, err: TypedError) -> LeveledResult<()> {
+        debug!("Partition \"{}\" received err: {err:?}", self.base.name());
+
+        let now = Instant::now();
+
+        let action = match self.base.part_hm().try_action(err.err()) {
+            None => {
+                warn!("Could not map \"{err:?}\" to action. Using Panic action instead");
+                match self.base.part_hm().panic {
+                    // We do not Handle Module Recovery actions here
+                    RecoveryAction::Module(_) => {
+                        return TypedResult::Err(err).lev(ErrorLevel::Partition)
+                    }
+                    RecoveryAction::Partition(action) => action,
+                }
+            }
+            // We do not Handle Module Recovery actions here
+            Some(RecoveryAction::Module(_)) => {
+                return TypedResult::Err(err).lev(ErrorLevel::Partition)
+            }
+            Some(RecoveryAction::Partition(action)) => action,
+        };
+
+        debug!("Handling: {err:?}");
+        debug!("Apply Partition Recovery Action: {action:?}");
+
+        // TODO do not unwrap/expect these errors. Maybe raise Module Level
+        // PartitionInit Error?
+        match action {
+            a653rs_linux_core::health::PartitionRecoveryAction::Idle => self
+                .run
+                .idle_transition(&self.base)
+                .expect("Idle Transition Failed"),
+            a653rs_linux_core::health::PartitionRecoveryAction::ColdStart => self
+                .run
+                .start_transition(&self.base, false, StartCondition::HmPartitionRestart)
+                .expect("Start(Cold) Transition Failed"),
+            a653rs_linux_core::health::PartitionRecoveryAction::WarmStart => self
+                .run
+                .start_transition(&self.base, false, StartCondition::HmPartitionRestart)
+                .expect("Start(Warm) Transition Failed"),
+        }
+
+        trace!("Partition Error Handling took: {:?}", now.elapsed());
+        Ok(())
     }
 }
 
@@ -773,5 +973,91 @@ impl PartitionConfig {
         };
 
         Ok(bin)
+    }
+}
+
+pub(crate) struct PeriodicPoller {
+    poll: Poller,
+    events: OwnedFd,
+}
+
+pub enum PeriodicEvent {
+    Timeout,
+    Frozen,
+    Call(PartitionCall),
+}
+
+impl PeriodicPoller {
+    const EVENTS_ID: usize = 1;
+    const RECEIVER_ID: usize = 2;
+
+    pub fn new(run: &Run) -> TypedResult<PeriodicPoller> {
+        let events = run.periodic_events()?;
+
+        let poll = Poller::new().typ(SystemError::Panic)?;
+        poll.add(events.as_raw_fd(), Event::readable(Self::EVENTS_ID))
+            .typ(SystemError::Panic)?;
+        poll.add(
+            run.receiver().as_raw_fd(),
+            Event::readable(Self::RECEIVER_ID),
+        )
+        .typ(SystemError::Panic)?;
+
+        Ok(PeriodicPoller { poll, events })
+    }
+
+    pub fn wait_timeout(&mut self, run: &mut Run, timeout: Timeout) -> TypedResult<PeriodicEvent> {
+        if run.is_periodic_frozen()? {
+            return Ok(PeriodicEvent::Frozen);
+        }
+
+        while timeout.has_time_left() {
+            let mut events = vec![];
+            self.poll
+                .wait(events.as_mut(), Some(timeout.remaining_time()))
+                .typ(SystemError::Panic)?;
+
+            for e in events {
+                match e.key {
+                    // Got a Frozen event
+                    Self::EVENTS_ID => {
+                        // Re-sub the readable event
+                        self.poll
+                            .modify(self.events.as_raw_fd(), Event::readable(Self::EVENTS_ID))
+                            .typ(SystemError::Panic)?;
+
+                        // Then check if the cg is actually frozen
+                        if run.is_periodic_frozen()? {
+                            return Ok(PeriodicEvent::Frozen);
+                        }
+                    }
+                    // got a call events
+                    Self::RECEIVER_ID => {
+                        // Re-sub the readable event
+                        // This will result in the event instantly being ready again should we have
+                        // something to read, but that is better than
+                        // accidentally missing an event (at the expense of one extra loop per
+                        // receive)
+                        self.poll
+                            .modify(
+                                run.receiver().as_raw_fd(),
+                                Event::readable(Self::RECEIVER_ID),
+                            )
+                            .typ(SystemError::Panic)?;
+
+                        // Now receive anything
+                        if let Some(call) = run.receiver().try_recv()? {
+                            return Ok(PeriodicEvent::Call(call));
+                        }
+                    }
+                    _ => {
+                        return Err(anyhow!("Unexpected Event Received: {e:?}"))
+                            .typ(SystemError::Panic)
+                    }
+                }
+            }
+        }
+
+        Ok(PeriodicEvent::Timeout)
     }
 }

--- a/hypervisor/src/hypervisor/scheduler.rs
+++ b/hypervisor/src/hypervisor/scheduler.rs
@@ -18,25 +18,33 @@ use super::partition::{Base, Run};
 
 /// A timeframe inside of a major frame.
 /// Both `start` and `end` are [Duration]s as they describe the time passed since the major frame's start.
-#[derive(Clone, Debug, Eq, Ord)]
+#[derive(Clone, Debug)]
 pub(crate) struct ScheduledTimeframe {
     pub partition_name: String,
     pub start: Duration,
     pub end: Duration,
 }
 
-impl PartialEq<Self> for ScheduledTimeframe {
+impl PartialEq for ScheduledTimeframe {
     fn eq(&self, other: &Self) -> bool {
-        self.start == other.start && self.end == other.end
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for ScheduledTimeframe {}
+
+impl Ord for ScheduledTimeframe {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.start.cmp(&other.start) {
+            Ordering::Equal => self.end.cmp(&other.end),
+            other => other,
+        }
     }
 }
 
 impl PartialOrd for ScheduledTimeframe {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        match self.start.partial_cmp(&other.start) {
-            Some(Ordering::Equal) => self.end.partial_cmp(&other.end),
-            other => other,
-        }
+        Some(self.cmp(other))
     }
 }
 

--- a/hypervisor/src/hypervisor/scheduler.rs
+++ b/hypervisor/src/hypervisor/scheduler.rs
@@ -113,9 +113,10 @@ impl<'a> PartitionTimeframeScheduler<'a> {
         }
     }
 
-    /// Takes in a [TypedResult] and makes the partition handle the `Err` variant.
-    /// A successful handling of the error will then return `Ok(None)`.
-    /// In case of `Ok(_)` the contained value is returned as `Ok(Some(_))`.
+    /// Takes in a [TypedResult] and makes the partition handle the `Err`
+    /// variant. A successful handling of the error will then return
+    /// `Ok(None)`. In case of `Ok(_)` the contained value is returned as
+    /// `Ok(Some(_))`.
     fn handle_partition_result<T>(&mut self, res: TypedResult<T>) -> LeveledResult<Option<T>> {
         res.map(|t| Some(t))
             .or_else(|err| self.partition.handle_error(err).map(|_| None))

--- a/hypervisor/src/hypervisor/scheduler.rs
+++ b/hypervisor/src/hypervisor/scheduler.rs
@@ -87,12 +87,16 @@ impl Timeout {
         Self { start, stop }
     }
 
-    fn remaining_time(&self) -> Duration {
+    pub fn remaining_time(&self) -> Duration {
         self.stop.saturating_sub(self.start.elapsed())
     }
 
-    fn time_left(&self) -> bool {
+    pub fn time_left(&self) -> bool {
         self.remaining_time() > Duration::ZERO
+    }
+
+    pub fn total_duration(&self) -> Duration {
+        self.stop
     }
 }
 

--- a/hypervisor/src/hypervisor/scheduler/schedule.rs
+++ b/hypervisor/src/hypervisor/scheduler/schedule.rs
@@ -1,0 +1,67 @@
+use std::cmp::Ordering;
+use std::time::Duration;
+
+use anyhow::bail;
+use itertools::Itertools;
+
+/// The schedule for the execution of partitions in each major frame.
+/// It consists of a [Vec] of timeframes sorted by their start time, which are
+/// guaranteed to not overlap.
+pub(crate) struct PartitionSchedule {
+    pub timeframes: Vec<ScheduledTimeframe>,
+}
+
+impl PartitionSchedule {
+    /// Creates a new partition schedule from given timeframes.
+    /// Returns `Err` if there are overlaps.
+    pub fn from_timeframes(mut timeframes: Vec<ScheduledTimeframe>) -> anyhow::Result<Self> {
+        timeframes.sort();
+
+        // Verify no overlaps
+        for (prev, next) in timeframes.iter().tuple_windows() {
+            if prev.end > next.start {
+                bail!("Overlapping partition timeframes: {prev:?}, {next:?})");
+            }
+        }
+
+        Ok(Self { timeframes })
+    }
+
+    /// Returns an iterator through all timeframes sorted by start time
+    pub fn iter(&self) -> impl Iterator<Item = &ScheduledTimeframe> {
+        self.timeframes.iter()
+    }
+}
+
+/// A timeframe inside of a major frame.
+/// Both `start` and `end` are [Duration]s as they describe the time passed
+/// since the major frame's start.
+#[derive(Clone, Debug)]
+pub(crate) struct ScheduledTimeframe {
+    pub partition_name: String,
+    pub start: Duration,
+    pub end: Duration,
+}
+
+impl PartialEq for ScheduledTimeframe {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for ScheduledTimeframe {}
+
+impl Ord for ScheduledTimeframe {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.start.cmp(&other.start) {
+            Ordering::Equal => self.end.cmp(&other.end),
+            other => other,
+        }
+    }
+}
+
+impl PartialOrd for ScheduledTimeframe {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/hypervisor/src/hypervisor/scheduler/timeout.rs
+++ b/hypervisor/src/hypervisor/scheduler/timeout.rs
@@ -1,0 +1,28 @@
+use std::time::{Duration, Instant};
+
+/// A simple object for keeping track of a timeout that starts at some instant
+/// and has a fixed duration. This object also exposes some basic functionality
+/// like querying the remaining time.
+#[derive(Copy, Clone)]
+pub(crate) struct Timeout {
+    start: Instant,
+    stop: Duration,
+}
+
+impl Timeout {
+    pub fn new(start: Instant, stop: Duration) -> Self {
+        Self { start, stop }
+    }
+
+    pub fn remaining_time(&self) -> Duration {
+        self.stop.saturating_sub(self.start.elapsed())
+    }
+
+    pub fn has_time_left(&self) -> bool {
+        self.remaining_time() > Duration::ZERO
+    }
+
+    pub fn total_duration(&self) -> Duration {
+        self.stop
+    }
+}


### PR DESCRIPTION
This PR refactors the scheduling to decrease coupling and code complexity between the scheduler and partition/process management code.
To do this, all the code for *how* processes are run is moved into `partition.rs`. In this way the scheduler is only responsible for  scheduling *when* the processes are ran.

Other minor refactorings include:
- introduce datatypes for storing the partition schedule: `scheduler::ScheduledTimeframe`, `scheduler::PartitionSchedule`
- use of `scheduler::Timeout` struct wherever possible to keep track of time