### PR TITLE
refactor(hypervisor): use an id to reference partitions instead of a string

### DIFF
--- a/hypervisor/src/hypervisor/config.rs
+++ b/hypervisor/src/hypervisor/config.rs
@@ -53,6 +53,7 @@ use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
 use std::time::Duration;
 
+use a653rs::bindings::PartitionId;
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 
@@ -103,7 +104,7 @@ pub struct Config {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Partition {
     /// Partition id
-    pub id: i64,
+    pub id: PartitionId,
 
     /// Partition name, used for example as prefix in the log printing
     pub name: String,
@@ -218,7 +219,7 @@ impl Config {
                     ScheduledTimeframe {
                         start,
                         end: start + p.duration,
-                        partition_name: p.name.clone(),
+                        partition: p.id,
                     }
                 })
             })

--- a/hypervisor/src/hypervisor/mod.rs
+++ b/hypervisor/src/hypervisor/mod.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
+use a653rs::bindings::PartitionId;
 use anyhow::anyhow;
 use once_cell::sync::OnceCell;
 
@@ -29,7 +30,7 @@ pub struct Hypervisor {
     cg: CGroup,
     major_frame: Duration,
     scheduler: Scheduler,
-    partitions: HashMap<String, Partition>,
+    partitions: HashMap<PartitionId, Partition>,
     sampling_channel: HashMap<String, Sampling>,
     prev_cg: PathBuf,
     _config: Config,
@@ -70,12 +71,12 @@ impl Hypervisor {
         }
 
         for p in config.partitions.iter() {
-            if hv.partitions.contains_key(&p.name) {
+            if hv.partitions.contains_key(&p.id) {
                 return Err(anyhow!("Partition \"{}\" already exists", p.name))
                     .lev_typ(SystemError::PartitionConfig, ErrorLevel::ModuleInit);
             }
             hv.partitions.insert(
-                p.name.clone(),
+                p.id,
                 Partition::new(hv.cg.get_path(), p.clone(), &hv.sampling_channel)
                     .lev(ErrorLevel::ModuleInit)?,
             );

--- a/hypervisor/src/hypervisor/partition.rs
+++ b/hypervisor/src/hypervisor/partition.rs
@@ -7,7 +7,7 @@ use std::process::{Command, Stdio};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
-use a653rs::bindings::PortDirection;
+use a653rs::bindings::{PartitionId, PortDirection};
 use a653rs::prelude::{OperatingMode, StartCondition};
 use anyhow::{anyhow, bail};
 use clone3::Clone3;
@@ -552,7 +552,7 @@ fn send_sockets(base: &Base) -> Result<IoTxRx, a653rs_linux_core::error::TypedEr
 pub(crate) struct Base {
     name: String,
     hm: PartitionHMTable,
-    id: i64,
+    id: PartitionId,
     bin: PathBuf,
     mounts: Vec<(PathBuf, PathBuf)>,
     cgroup: CGroup,

--- a/hypervisor/src/hypervisor/scheduler.rs
+++ b/hypervisor/src/hypervisor/scheduler.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::thread::sleep;
 use std::time::Instant;
 
+use a653rs::bindings::PartitionId;
 use a653rs::prelude::OperatingMode;
 use anyhow::anyhow;
 
@@ -30,7 +31,7 @@ impl Scheduler {
     pub fn run_major_frame(
         &mut self,
         current_frame_start: Instant,
-        partitions_by_name: &mut HashMap<String, Partition>,
+        partitions: &mut HashMap<PartitionId, Partition>,
         sampling_channels_by_name: &mut HashMap<String, Sampling>,
     ) -> LeveledResult<()> {
         for timeframe in self.schedule.iter() {
@@ -41,8 +42,8 @@ impl Scheduler {
             );
 
             let timeframe_timeout = Timeout::new(current_frame_start, timeframe.end);
-            let partition = partitions_by_name
-                .get_mut(&timeframe.partition_name)
+            let partition = partitions
+                .get_mut(&timeframe.partition)
                 .expect("partition to exist because its name comes from `timeframe`");
             PartitionTimeframeScheduler::new(partition, timeframe_timeout).run()?;
 

--- a/hypervisor/src/hypervisor/scheduler/schedule.rs
+++ b/hypervisor/src/hypervisor/scheduler/schedule.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::time::Duration;
 
+use a653rs::bindings::PartitionId;
 use anyhow::bail;
 use itertools::Itertools;
 
@@ -38,7 +39,7 @@ impl PartitionSchedule {
 /// since the major frame's start.
 #[derive(Clone, Debug)]
 pub(crate) struct ScheduledTimeframe {
-    pub partition_name: String,
+    pub partition: PartitionId,
     pub start: Duration,
     pub end: Duration,
 }


### PR DESCRIPTION
Currently the String type is used as a key (e.g. `HashMap<String, Partition>`) to reference partitions. Every partition already has a numeric ID assigned to it, which we might as well use.

This PR replaces the `String` keys with numeric `PartitionId`s. The `PartitionId` type is already provided by the `a653rs` crate.