### PR TITLE
fix(ping_client, ping_server): wait major frame after sampling port error

### DIFF
--- a/examples/ping_client/src/main.rs
+++ b/examples/ping_client/src/main.rs
@@ -1,7 +1,8 @@
 use a653rs::partition;
 use a653rs::prelude::PartitionExt;
-use a653rs_linux::partition::ApexLogger;
 use log::LevelFilter;
+
+use a653rs_linux::partition::ApexLogger;
 
 fn main() {
     ApexLogger::install_panic_hook();
@@ -84,6 +85,7 @@ mod ping_client {
                 Ok((validity, bytes)) => (validity, bytes),
                 Err(e) => {
                     warn!("Failed to receive ping response: {e:?}");
+                    ctx.periodic_wait().unwrap();
                     continue;
                 }
             };

--- a/examples/ping_server/src/main.rs
+++ b/examples/ping_server/src/main.rs
@@ -1,7 +1,8 @@
 use a653rs::partition;
 use a653rs::prelude::PartitionExt;
-use a653rs_linux::partition::ApexLogger;
 use log::LevelFilter;
+
+use a653rs_linux::partition::ApexLogger;
 
 fn main() {
     ApexLogger::install_panic_hook();
@@ -49,14 +50,13 @@ mod ping_server {
     fn periodic_ping_server(ctx: periodic_ping_server::Context) {
         info!("started ping_server process");
         loop {
-            info!("forwarding request as response ");
-
             // allocate a buffer to receive into
             let mut buf = [0u8; 32];
 
             // receive a request, storing it to `buf`
             if let Err(e) = ctx.ping_request.unwrap().receive(&mut buf) {
                 warn!("Failed to receive ping request: {e:?}");
+                ctx.periodic_wait().unwrap();
                 continue;
             }
 
@@ -65,6 +65,8 @@ mod ping_server {
             let SystemTime::Normal(time) = ctx.get_time() else {
                 panic!("could not read time");
             };
+
+            info!("forwarding request as response");
 
             // convert the current time to an u128 integer representing nanoseconds, and
             // serialize the integer to a byte array


### PR DESCRIPTION
The behaviour of the ping example is indeterministic. Sometimes the ping will succeed on the first attempt, while some other times it will take an extended amount of time (>5-10s not being rare).

This happens because both `ping_server` and `ping_client` call `continue` after failing to receive a message from both sampling channels.
This in turn causes them to keep trying to receive messages continuously, which is likely to cause them being frozen by the hypervisor in some invalid state.

This indeterministic behaviour is prevented by this PR, by making both periodic processes wait for the next major frame after failing to receive a message.